### PR TITLE
Support FreeBSD

### DIFF
--- a/confu/builds/unix.py
+++ b/confu/builds/unix.py
@@ -28,6 +28,9 @@ class UnixBuild(Build):
             elif confu.platform.host.is_macos and toolchain == "auto" or toolchain == "clang":
                 self.toolchain.cc = "clang"
                 self.toolchain.cxx = "clang++"
+            elif confu.platform.host.is_freebsd and toolchain == "auto" or toolchain == "clang":
+                self.toolchain.cc = "clang"
+                self.toolchain.cxx = "clang++"
             self.toolchain.ar = "ar"
             self.toolchain.ranlib = "ranlib"
             self.toolchain.strip = "strip"

--- a/confu/platform.py
+++ b/confu/platform.py
@@ -140,7 +140,7 @@ class Platform:
 
     @property
     def is_x86_64(self):
-        return self.arch == "x86_64"
+        return self.arch in ["x86_64", "amd64"]
 
     @property
     def is_ppc64(self):
@@ -173,6 +173,10 @@ class Platform:
     @property
     def is_android(self):
         return self.os == "android"
+
+    @property
+    def is_freebsd(self):
+        return self.os == "freebsd"
 
     @property
     def is_macos(self):
@@ -228,6 +232,9 @@ def detect_host():
     elif sys.platform == "win32":
         if machine in x86_64_machines:
             return "x86_64-windows"
+    elif sys.platform.startswith("freebsd"):
+        if machine in x86_64_machines:
+            return "x86_64-freebsd"
     else:
         logging.critical("failed to detect the host platform: "
                          "sys.platform = {sys.platform}".format(sys=sys))

--- a/confu/tools/peachpy.py
+++ b/confu/tools/peachpy.py
@@ -29,6 +29,7 @@ class PeachPy(Tool):
     def _record_rules(self, ninja):
     	abi, imageformat = {
     		"x86_64-linux-gnu":   ("sysv", "elf"),
+    		"x86_64-freebsd":     ("sysv", "elf"),
     		"x86_64-macos":       ("sysv", "mach-o"),
     		"x86_64-nacl-newlib": ("nacl", "elf"),
     		"x86_64-nacl-gnu":    ("nacl", "elf"),

--- a/confu/tools/toolchains/unix.py
+++ b/confu/tools/toolchains/unix.py
@@ -18,7 +18,7 @@ class UnixToolchain(Toolchain):
         self.ldflags = []
         self.ldlibs = []
         self.optflag = "-O2"
-        if self.target.is_glibc:
+        if self.target.is_glibc or self.target.is_freebsd:
             self.cflags.append("-pthread")
             self.cxxflags.append("-pthread")
             self.ldflags.append("-pthread")

--- a/confu/validators.py
+++ b/confu/validators.py
@@ -171,6 +171,7 @@ platform_alternatives = {
     "x86_64-android": [],
     "x86-android": [],
     "x86_64-macos": [],
+    "x86_64-freebsd": [],
     "x86_64-nacl-gnu": [],
     "x86_64-nacl-newlib": ["x86_64-nacl"],
     "pnacl-nacl-newlib": ["pnacl", "pnacl-nacl", "pnacl-newlib"],


### PR DESCRIPTION
This change allows `amd64` as a recognized architecture, as this is what FreeBSD calls `x86_64`. It also adds an `is_freebsd` property to the `Platform` class and configures the default toolchain's compiler to be Clang on FreeBSD.

This is part of an attempt to bring FreeBSD support to NNPACK.